### PR TITLE
Removed dependency to jgrapht-ext

### DIFF
--- a/Example/pom.xml
+++ b/Example/pom.xml
@@ -35,12 +35,7 @@
         <dependency>
             <groupId>org.jgrapht</groupId>
             <artifactId>jgrapht-core</artifactId>
-            <version>0.9.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jgrapht</groupId>
-            <artifactId>jgrapht-ext</artifactId>
-            <version>0.9.1</version>
+            <version>1.0.1</version>
         </dependency>
     </dependencies>
 </project>

--- a/Example/pom.xml
+++ b/Example/pom.xml
@@ -4,9 +4,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>Example</groupId>
+    <groupId>com.github.systemdir.gml</groupId>
     <artifactId>Example</artifactId>
-    <version>1.0.0</version>
+    <version>2.0.0-cgm-1</version>
 
     <!-- Default build settings / plugins -->
     <build>
@@ -16,7 +16,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -30,12 +29,17 @@
         <dependency>
             <groupId>com.github.systemdir.gml</groupId>
             <artifactId>GMLWriterForYed</artifactId>
-            <version>1.0.0</version>
+            <version>2.0.0-cgm-1</version>
         </dependency>
         <dependency>
             <groupId>org.jgrapht</groupId>
             <artifactId>jgrapht-core</artifactId>
             <version>1.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>13.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/GMLWriter/pom.xml
+++ b/GMLWriter/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.systemdir.gml</groupId>
     <artifactId>GMLWriterForYed</artifactId>
-    <version>1.0.0</version>
+    <version>2.0.0-cgm-1</version>
     <packaging>jar</packaging>
 
     <name>GML Writer for yED</name>
@@ -50,7 +50,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -74,7 +73,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -96,21 +94,6 @@
                     <autoReleaseAfterClose>true</autoReleaseAfterClose>
                 </configuration>
             </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.5</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 
@@ -121,6 +104,7 @@
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
             <version>13.0</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jgrapht</groupId>
@@ -128,4 +112,31 @@
             <version>1.0.1</version>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>GPGSign</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.5</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/GMLWriter/pom.xml
+++ b/GMLWriter/pom.xml
@@ -125,12 +125,7 @@
         <dependency>
             <groupId>org.jgrapht</groupId>
             <artifactId>jgrapht-core</artifactId>
-            <version>1.0.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jgrapht</groupId>
-            <artifactId>jgrapht-ext</artifactId>
-            <version>1.0.0</version>
+            <version>1.0.1</version>
         </dependency>
     </dependencies>
 </project>

--- a/GMLWriter/src/com/github/systemdir/gml/model/GraphicDefinition.java
+++ b/GMLWriter/src/com/github/systemdir/gml/model/GraphicDefinition.java
@@ -78,9 +78,8 @@ public abstract class GraphicDefinition {
     protected Integer lineWidth;
     @NotNull
     protected Color lineColor;
-    
 
-    public GraphicDefinition(Builder builder) {
+    protected GraphicDefinition(Builder builder) {
         this.lineColor=builder.lineColor;
         this.lineType = builder.lineType;
         this.lineWidth = builder.lineWidth;
@@ -89,9 +88,4 @@ public abstract class GraphicDefinition {
         this.fontStyle = builder.fontStyle;
         this.labelColour = builder.labelColour;
     }
-
-
-    
-
-    
 }

--- a/GMLWriter/src/com/github/systemdir/gml/model/Tools.java
+++ b/GMLWriter/src/com/github/systemdir/gml/model/Tools.java
@@ -61,8 +61,6 @@ class Tools {
 
     /**
      * create rgba hex from a java color
-     * @param color
-     * @return
      */
     static String getHex(Color color) {
         return String.format("#%02x%02x%02x%02x", color.getRed(), color.getGreen(), color.getBlue(), color.getAlpha());

--- a/GMLWriter/src/com/github/systemdir/gml/model/UniqueIntIdFunction.java
+++ b/GMLWriter/src/com/github/systemdir/gml/model/UniqueIntIdFunction.java
@@ -1,0 +1,32 @@
+package com.github.systemdir.gml.model;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Creates a unique integer-based id for each object passed to the function.
+ * <p>
+ * Uniqueness of an object is determined by the equals, and hashCode funktion of the passed objects.
+ * <p>
+ * This class is NOT thread safe.
+ *
+ * @author Andreas Hofstadler, COREFT
+ */
+public class UniqueIntIdFunction<T> implements Function<T, String> {
+    private Map<T, String> idMap = new HashMap<>();
+    private int nextId = 1;
+
+    @Override
+    public String apply(T t) {
+        String existing = idMap.get(t);
+        if (existing != null) {
+            return existing;
+        } else {
+            String id = String.valueOf(nextId);
+            nextId++;
+            idMap.put(t, id);
+            return id;
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![License](https://img.shields.io/badge/license-LGPL%202.1-blue.svg)](http://www.gnu.org/licenses/lgpl-2.1.html) [![Language](http://img.shields.io/badge/language-java-brightgreen.svg)](https://www.java.com/)
 # GML-Writer-for-yED
-Extends the gml export of JGraphT to better supports the import to yED.
+Extends the Graph Modeling Language (GML) export of JGraphT to better supports the import to yED.
 
 Please note that the GML-Writer-for-yED is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![License](https://img.shields.io/badge/license-LGPL%202.1-blue.svg)](http://www.gnu.org/licenses/lgpl-2.1.html) [![Language](http://img.shields.io/badge/language-java-brightgreen.svg)](https://www.java.com/)
 # GML-Writer-for-yED
-Extends the Graph Modeling Language (GML) export of JGraphT to better supports the import to yED.
+Extends the [Graph Modeling Language (GML)](https://en.wikipedia.org/wiki/Graph_Modelling_Language) export of JGraphT to better supports the import to yED.
 
 Please note that the GML-Writer-for-yED is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 # GML-Writer-for-yED
 Extends the [Graph Modeling Language (GML)](https://en.wikipedia.org/wiki/Graph_Modelling_Language) export of JGraphT to better supports the import to yED.
 
-Please note that the GML-Writer-for-yED is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-
 * Released: January 17, 2017
 * Based on: JgraphT (and yED)
 * Written by [Hayato Hess](mailto:hayato.hess@gmail.com) and Contributors

--- a/pom.xml
+++ b/pom.xml
@@ -4,9 +4,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>GMLwriterForYed</groupId>
-    <artifactId>GMLwriterForYedParentProject</artifactId>
-    <version>2.0.0</version>
+    <groupId>com.github.systemdir.gml</groupId>
+    <artifactId>GMLwriterForYed-Parent</artifactId>
+    <version>2.0.0-cgm-1</version>
 
     <packaging>pom</packaging>
 


### PR DESCRIPTION
Using java.util.Function instead of *NameProvider interfaces.

Fixed labels containing " and & characters

Upgraded to jgrapht-core 1.0.1

Main reasons for doing this are the messed up dependencies of jgrapht-ext and the fact that most classes in that library are deprecated anyways.

Changes the API of the builder, so this is a breaking change.