### PR TITLE
JgraphT 1.5 + JDK 11 migration

### DIFF
--- a/GMLWriter/pom.xml
+++ b/GMLWriter/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.systemdir.gml</groupId>
     <artifactId>GMLWriterForYed</artifactId>
-    <version>2.1.0</version>
+    <version>2.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>GML Writer for yED</name>
@@ -51,15 +51,15 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
             
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -73,6 +73,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -109,7 +110,7 @@
         <dependency>
             <groupId>org.jgrapht</groupId>
             <artifactId>jgrapht-core</artifactId>
-            <version>1.0.1</version>
+            <version>1.5.0</version>
         </dependency>
     </dependencies>
 

--- a/GMLWriter/src/com/github/systemdir/gml/YedGmlWriter.java
+++ b/GMLWriter/src/com/github/systemdir/gml/YedGmlWriter.java
@@ -41,9 +41,7 @@ import com.github.systemdir.gml.model.UniqueIntIdFunction;
 import com.github.systemdir.gml.model.YedGmlGraphicsProvider;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.jgrapht.DirectedGraph;
 import org.jgrapht.Graph;
-import org.jgrapht.UndirectedGraph;
 
 import java.io.PrintWriter;
 import java.io.Writer;
@@ -60,11 +58,9 @@ import static com.github.systemdir.gml.YedGmlWriter.PrintLabels.*;
 
 /**
  * Exports a graph into a GML file (Graph Modelling Language) for yED.
- * <p>
  * <p>For a description of the format see <a
  * href="http://www.infosun.fmi.uni-passau.de/Graphlet/GML/">
  * http://www.infosun.fmi.uni-passau.de/Graphlet/GML/</a>.</p>
- * <p>
  *
  * @author (GML writer) Dimitrios Michail
  * @author (yED extension) Hayato Hess
@@ -95,6 +91,7 @@ public class YedGmlWriter<V, E, G> {
          *
          * @param groupMapping Maps groups to the vertices they belong to. Map must not contain null values.
          * @param groupLabelProvider Optional label function for the group. When null, toString() is used for generating group labels.
+         * @return this
          */
         public Builder<V1, E1, G1> setGroups(Map<G1, ? extends Set<V1>> groupMapping, Function<G1, String> groupLabelProvider) {
             this.groupMapping = groupMapping;
@@ -399,23 +396,12 @@ public class YedGmlWriter<V, E, G> {
     }
 
     /**
-     * Exports an undirected graph into a PLAIN text file in GML format.
+     * Exports a graph into a PLAIN text file in GML format.
      *
      * @param output the writer to which the graph to be exported
-     * @param g the undirected graph to be exported
+     * @param g the graph to be exported
      */
-    public void export(Writer output, UndirectedGraph<V, E> g) {
-        export(output, g, false);
+    public void export(Writer output, Graph<V, E> g) {
+        export(output, g, g.getType().isDirected());
     }
-
-    /**
-     * Exports a directed graph into a PLAIN text file in GML format.
-     *
-     * @param output the writer to which the graph to be exported
-     * @param g the directed graph to be exported
-     */
-    public void export(Writer output, DirectedGraph<V, E> g) {
-        export(output, g, true);
-    }
-
 }

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.systemdir.gml</groupId>
     <artifactId>GMLwriterForYed-Parent</artifactId>
-    <version>2.1.0</version>
+    <version>2.2.0-SNAPSHOT</version>
 
     <packaging>pom</packaging>
 


### PR DESCRIPTION
Update to JgraphT 1.5.0 which also requires JDK update. 
Main change is determining directed/undirected aspect based on Graph interface due to the removal of specific DirectedGraph/UndirectedGraph interfaces.